### PR TITLE
feat: prometheus in vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ yarn-error.log*
 !/vagrant/elastic/
 !/vagrant/control-plane/
 !/vagrant/redis/
+!/vagrant/prometheus
 !/vagrant/README.md
 !Vagrantfile
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,14 +1,15 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-KUMA_VERSION = "0.3.1"
+KUMA_VERSION = "0.3.2-rc3"
 KUMA_HOME    = "/opt/kuma"
 
-KUMA_CONTROL_PLANE_IP = "192.168.33.10"
-FRONTEND_IP           = "192.168.33.20"
-BACKEND_IP            = "192.168.33.30"
-ELASTIC_IP            = "192.168.33.40"
-REDIS_IP              = "192.168.33.50"
+KUMA_CONTROL_PLANE_IP      = "192.168.33.10"
+FRONTEND_IP                = "192.168.33.20"
+BACKEND_IP                 = "192.168.33.30"
+ELASTIC_IP                 = "192.168.33.40"
+REDIS_IP                   = "192.168.33.50"
+PROMETHEUS_IP              = "192.168.33.60"
 
 Vagrant.configure("2") do |config|
 
@@ -48,6 +49,18 @@ Vagrant.configure("2") do |config|
     node.vm.provision "configure_kumactl", type: "shell", path: "common/configure_kumactl.sh", privileged: false
     node.vm.provision "register_dataplane", type: "shell", path: "common/register_dataplane.sh", env: {"KUMA_DATAPLANE_FILE" => "/vagrant/elastic/kuma/dataplane.yaml", "KUMA_DATAPLANE_IP" => ELASTIC_IP}, privileged: false, run: "always"
     node.vm.provision "await_kuma-dp", type: "shell", path: "common/await_service.sh", env: {"SERVICE_URL" => "http://localhost:9901/ready"}, privileged: false, run: "always"
+  end
+
+  config.vm.define "prometheus" do |node|
+    node.vm.box = "ubuntu/xenial64"
+    node.vm.hostname = "prometheus"
+    node.vm.network :private_network, ip: PROMETHEUS_IP
+    node.vm.provision "update_etc_hosts", type: "shell", path: "common/update_etc_hosts.sh", env: { "KUMA_CONTROL_PLANE_IP" => KUMA_CONTROL_PLANE_IP }
+    node.vm.provision "file-config", type: "file", source: "prometheus/app/prometheus.yaml", destination: "/tmp/prometheus.yaml"
+    node.vm.provision "file-service", type: "file", source: "prometheus/app/prometheus.service", destination: "/tmp/prometheus.service"
+    node.vm.provision "install_prometheus", type: "shell", path: "prometheus/app/install.sh", privileged: true
+    node.vm.provision "download_kuma", type: "shell", path: "common/download_kuma.sh", env: {"KUMA_VERSION" => KUMA_VERSION, "KUMA_HOME" => KUMA_HOME }
+    node.vm.provision "install_kuma-prometheus-sd", type: "shell", path: "prometheus/kuma/install-kuma-prometheus-sd.sh"
   end
 
   config.vm.define "backend" do |node|

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -9,7 +9,7 @@ FRONTEND_IP                = "192.168.33.20"
 BACKEND_IP                 = "192.168.33.30"
 ELASTIC_IP                 = "192.168.33.40"
 REDIS_IP                   = "192.168.33.50"
-PROMETHEUS_IP              = "192.168.33.60"
+PROMETHEUS_IP              = "192.168.33.70"
 
 Vagrant.configure("2") do |config|
 
@@ -56,9 +56,7 @@ Vagrant.configure("2") do |config|
     node.vm.hostname = "prometheus"
     node.vm.network :private_network, ip: PROMETHEUS_IP
     node.vm.provision "update_etc_hosts", type: "shell", path: "common/update_etc_hosts.sh", env: { "KUMA_CONTROL_PLANE_IP" => KUMA_CONTROL_PLANE_IP }
-    node.vm.provision "file-config", type: "file", source: "prometheus/app/prometheus.yaml", destination: "/tmp/prometheus.yaml"
-    node.vm.provision "file-service", type: "file", source: "prometheus/app/prometheus.service", destination: "/tmp/prometheus.service"
-    node.vm.provision "install_prometheus", type: "shell", path: "prometheus/app/install.sh", privileged: true
+    node.vm.provision "install_prometheus", type: "shell", path: "prometheus/app/install.sh", privileged: true, env: {"PROMETHEUS_VERSION": "2.15.2"}
     node.vm.provision "download_kuma", type: "shell", path: "common/download_kuma.sh", env: {"KUMA_VERSION" => KUMA_VERSION, "KUMA_HOME" => KUMA_HOME }
     node.vm.provision "install_kuma-prometheus-sd", type: "shell", path: "prometheus/kuma/install-kuma-prometheus-sd.sh"
   end

--- a/vagrant/prometheus/app/install.sh
+++ b/vagrant/prometheus/app/install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+set -e
+
+cat << "EOF"
+PROMETHEUS
+EOF
+
+# Add user
+useradd -M -r -s /bin/false prometheus
+
+# Create directory in which Prometheus will be installed
+mkdir /etc/prometheus /var/lib/prometheus
+
+# Get Prometheus
+wget https://github.com/prometheus/prometheus/releases/download/v2.15.2/prometheus-2.15.2.linux-amd64.tar.gz
+
+# Unpack and copy binaries
+tar xzf prometheus-2.15.2.linux-amd64.tar.gz
+cp prometheus-2.15.2.linux-amd64/prometheus /usr/local/bin/
+cp prometheus-2.15.2.linux-amd64/promtool /usr/local/bin/
+
+# Set permissions for binaries for added user
+chown prometheus:prometheus /usr/local/bin/prometheus
+chown prometheus:prometheus /usr/local/bin/promtool
+
+# Copy config
+cp /tmp/prometheus.yaml /etc/prometheus/prometheus.yaml
+
+# Set permissions for Prometheus data directories
+chown -R prometheus:prometheus /etc/prometheus
+chown prometheus:prometheus /var/lib/prometheus
+
+# Add Prometheus service
+cp /tmp/prometheus.service /etc/systemd/system/prometheus.service
+
+# Always run the `systemctl daemon-reload` command after creating new unit files or modifying existing unit files.
+# Otherwise, the `systemctl start` or `systemctl enable` commands could fail due to a mismatch between states of systemd
+# and actual service unit files on disk.
+systemctl daemon-reload
+
+# Ensure the `prometheus` service starts whenever the system boots
+systemctl enable prometheus
+
+# Start `prometheus` service right away
+systemctl start prometheus

--- a/vagrant/prometheus/app/install.sh
+++ b/vagrant/prometheus/app/install.sh
@@ -2,6 +2,11 @@
 
 set -e
 
+if [ -z "${PROMETHEUS_VERSION}" ]; then
+  echo "Error: environment variable PROMETHEUS_VERSION is not set"
+  exit 1
+fi
+
 cat << "EOF"
 PROMETHEUS
 EOF
@@ -13,26 +18,26 @@ useradd -M -r -s /bin/false prometheus
 mkdir /etc/prometheus /var/lib/prometheus
 
 # Get Prometheus
-wget https://github.com/prometheus/prometheus/releases/download/v2.15.2/prometheus-2.15.2.linux-amd64.tar.gz
+wget https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz
 
 # Unpack and copy binaries
-tar xzf prometheus-2.15.2.linux-amd64.tar.gz
-cp prometheus-2.15.2.linux-amd64/prometheus /usr/local/bin/
-cp prometheus-2.15.2.linux-amd64/promtool /usr/local/bin/
+tar xzf prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz
+cp prometheus-${PROMETHEUS_VERSION}.linux-amd64/prometheus /usr/local/bin/
+cp prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool /usr/local/bin/
 
 # Set permissions for binaries for added user
 chown prometheus:prometheus /usr/local/bin/prometheus
 chown prometheus:prometheus /usr/local/bin/promtool
 
 # Copy config
-cp /tmp/prometheus.yaml /etc/prometheus/prometheus.yaml
+cp /vagrant/prometheus/app/prometheus.yaml /etc/prometheus/prometheus.yaml
 
 # Set permissions for Prometheus data directories
 chown -R prometheus:prometheus /etc/prometheus
 chown prometheus:prometheus /var/lib/prometheus
 
 # Add Prometheus service
-cp /tmp/prometheus.service /etc/systemd/system/prometheus.service
+cp /vagrant/prometheus/app/prometheus.service /etc/systemd/system/prometheus.service
 
 # Always run the `systemctl daemon-reload` command after creating new unit files or modifying existing unit files.
 # Otherwise, the `systemctl start` or `systemctl enable` commands could fail due to a mismatch between states of systemd

--- a/vagrant/prometheus/app/prometheus.service
+++ b/vagrant/prometheus/app/prometheus.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Prometheus Time Series Collection and Processing Server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User=prometheus
+Group=prometheus
+Type=simple
+ExecStart=/usr/local/bin/prometheus \
+    --config.file /etc/prometheus/prometheus.yaml \
+    --storage.tsdb.path /var/lib/prometheus/ \
+
+[Install]
+WantedBy=multi-user.target

--- a/vagrant/prometheus/app/prometheus.service
+++ b/vagrant/prometheus/app/prometheus.service
@@ -6,7 +6,8 @@ After=network-online.target
 [Service]
 User=prometheus
 Group=prometheus
-Type=simple
+Restart=always
+RestartSec=1s
 ExecStart=/usr/local/bin/prometheus \
     --config.file /etc/prometheus/prometheus.yaml \
     --storage.tsdb.path /var/lib/prometheus/ \

--- a/vagrant/prometheus/app/prometheus.yaml
+++ b/vagrant/prometheus/app/prometheus.yaml
@@ -4,4 +4,4 @@ scrape_configs:
   file_sd_configs:
   - refresh_interval: 1s
     files:
-    - /tmp/kuma.io/kuma-prometheus-sd/kuma.file_sd.json
+    - /var/run/kuma.io/kuma-prometheus-sd/kuma.file_sd.json

--- a/vagrant/prometheus/app/prometheus.yaml
+++ b/vagrant/prometheus/app/prometheus.yaml
@@ -1,0 +1,7 @@
+scrape_configs:
+- job_name: 'kuma-sd'
+  scrape_interval: "5s"
+  file_sd_configs:
+  - refresh_interval: 1s
+    files:
+    - /tmp/kuma.io/kuma-prometheus-sd/kuma.file_sd.json

--- a/vagrant/prometheus/kuma/install-kuma-prometheus-sd.sh
+++ b/vagrant/prometheus/kuma/install-kuma-prometheus-sd.sh
@@ -3,8 +3,8 @@
 set -e
 
 # Create directory and set proper permissions for generated files by kuma-prometheus-sd
-mkdir -p /tmp/kuma.io/kuma-prometheus-sd/
-chown prometheus:prometheus /tmp/kuma.io/kuma-prometheus-sd/
+mkdir -p /var/run/kuma.io/kuma-prometheus-sd/
+chown prometheus:prometheus /var/run/kuma.io/kuma-prometheus-sd/
 
 cp /vagrant/prometheus/kuma/kuma-prometheus-sd.service /etc/systemd/system/kuma-prometheus-sd.service
 

--- a/vagrant/prometheus/kuma/install-kuma-prometheus-sd.sh
+++ b/vagrant/prometheus/kuma/install-kuma-prometheus-sd.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -e
+
+# Create directory and set proper permissions for generated files by kuma-prometheus-sd
+mkdir -p /tmp/kuma.io/kuma-prometheus-sd/
+chown prometheus:prometheus /tmp/kuma.io/kuma-prometheus-sd/
+
+cp /vagrant/prometheus/kuma/kuma-prometheus-sd.service /etc/systemd/system/kuma-prometheus-sd.service
+
+# Always run the `systemctl daemon-reload` command after creating new unit files or modifying existing unit files.
+# Otherwise, the `systemctl start` or `systemctl enable` commands could fail due to a mismatch between states of systemd
+# and actual service unit files on disk.
+systemctl daemon-reload
+
+# Ensure the `kuma-prometheus-sd` service starts whenever the system boots
+systemctl enable kuma-prometheus-sd
+
+# Start `kuma-prometheus-sd` service right away
+systemctl start kuma-prometheus-sd

--- a/vagrant/prometheus/kuma/kuma-prometheus-sd.service
+++ b/vagrant/prometheus/kuma/kuma-prometheus-sd.service
@@ -6,7 +6,7 @@ Documentation=https://kuma.io
 [Service]
 Environment=KUMA_MONITORING_ASSIGNMENT_CLIENT_NAME=prometheus
 Environment=KUMA_CONTROL_PLANE_API_SERVER_URL=http://kuma-cp:5681
-Environment=KUMA_PROMETHEUS_OUTPUT_FILE=/tmp/kuma.io/kuma-prometheus-sd/kuma.file_sd.json
+Environment=KUMA_PROMETHEUS_OUTPUT_FILE=/var/run/kuma.io/kuma-prometheus-sd/kuma.file_sd.json
 ExecStart=/opt/kuma/bin/kuma-prometheus-sd run
 Restart=always
 RestartSec=1s

--- a/vagrant/prometheus/kuma/kuma-prometheus-sd.service
+++ b/vagrant/prometheus/kuma/kuma-prometheus-sd.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Prometheus SD deployed next to the "prometheus" to integrate with Kuma.
+After=network.target
+Documentation=https://kuma.io
+
+[Service]
+Environment=KUMA_MONITORING_ASSIGNMENT_CLIENT_NAME=prometheus
+Environment=KUMA_CONTROL_PLANE_API_SERVER_URL=http://kuma-cp:5681
+Environment=KUMA_PROMETHEUS_OUTPUT_FILE=/tmp/kuma.io/kuma-prometheus-sd/kuma.file_sd.json
+ExecStart=/opt/kuma/bin/kuma-prometheus-sd run
+Restart=always
+RestartSec=1s
+# disable rate limiting on start attempts
+StartLimitIntervalSec=0
+StartLimitBurst=0
+User=prometheus
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## PR Details

Prometheus setup in Vagrant. It uses new kuma-prometheus-sd binary to pull the targets. Remember to enable `metrics.prometheus: {}` on mesh resource to test it.