### PR TITLE
chore(*) remove nginx

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -18,4 +18,4 @@ RUN npm run build
 RUN apk add curl jq
 
 EXPOSE 8080
-CMD [ "http-server", "dist" ]
+ENTRYPOINT [ "http-server", "dist"]

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -78,9 +78,9 @@ In the following steps, we will be using the pod name of the `kuma-demo-app-****
 
 ### 3. Port-forward the sample application to access the front-end UI at http://localhost:8080
 
-<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080:80
-Forwarding from 127.0.0.1:8080 -> 80
-Forwarding from [::1]:8080 -> 80
+<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080
+Forwarding from 127.0.0.1:8080 -> 8080
+Forwarding from [::1]:8080 -> 8080
 </code></pre>
 
 Now you can access the marketplace application through your web browser at http://localhost:8080.
@@ -206,9 +206,9 @@ redis-master-5b5978b77f-hwjvd           2/2     Running   0          37s
 
 ### 9. Port-forward the sample application again to access the front-end UI at http://localhost:8080
 
-<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080:80
-Forwarding from 127.0.0.1:8080 -> 80
-Forwarding from [::1]:8080 -> 80
+<pre><code>$ kubectl port-forward <b>${KUMA_DEMO_APP_POD_NAME}</b> -n kuma-demo 8080
+Forwarding from 127.0.0.1:8080 -> 8080
+Forwarding from [::1]:8080 -> 8080
 </code></pre>
 
 Now you can access the marketplace application through your web browser at http://localhost:8080 with Envoy handling all the traffic between the services. Happy shopping!

--- a/kubernetes/kuma-demo-aio.yaml
+++ b/kubernetes/kuma-demo-aio.yaml
@@ -253,48 +253,6 @@ spec:
         - containerPort: 3001
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: demo-app-config
-  namespace: kuma-demo
-data:
-  nginx.conf: |
-    user  nginx;
-    worker_processes  1;
-    error_log  /var/log/nginx/error.log warn;
-    pid        /var/run/nginx.pid;
-    events {
-        worker_connections  1024;
-    }
-    http {
-        default_type  application/octet-stream;
-        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
-                          '$status $body_bytes_sent "$http_referer" '
-                          '"$http_user_agent" "$http_x_forwarded_for"';
-        access_log  /var/log/nginx/access.log  main;
-        keepalive_timeout  65;
-        upstream frontend {
-            server localhost:8080;
-        }
-        upstream backend {
-            server backend:3001;
-            keepalive_timeout 0s;
-        }
-        server {
-            listen       80;
-            server_name  localhost;
-            location /items {
-                proxy_pass http://backend;
-                proxy_http_version 1.1;
-            }
-            location / {
-                proxy_pass http://frontend;
-                proxy_http_version 1.1;
-            }
-        }
-    }
----
-apiVersion: v1
 kind: Service
 metadata:
   name: frontend
@@ -307,6 +265,7 @@ spec:
   ports:
   - name: http
     port: 80
+    targetPort: 8080
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -328,18 +287,7 @@ spec:
         env: prod
     spec:
       containers:
-      - image: nginx
-        name: nginx
-        imagePullPolicy: IfNotPresent
-        ports:
-        - containerPort: 80
-        volumeMounts:
-        - name: demo-app-config
-          mountPath: /etc/nginx/
       - name: kuma-fe
-        image: kvn0218/kuma-demo-fe:kubecon
+        image: kvn0218/kuma-demo-fe:http-server
+        args: ["-P", "http://backend:3001"]
         imagePullPolicy: IfNotPresent
-      volumes:
-      - name: demo-app-config
-        configMap:
-          name: demo-app-config


### PR DESCRIPTION
## PR Details

This PR simplifies setup by removing Nginx. Also it is consistent with Vagrant. We can use the same server (http-server) to serve web app and proxy requests to the backend.

All headers are passed by http-server therefore when tracing will be applied, they will be passed to the backend.

@devadvocado please publish the docker with `kvn0218/kuma-demo-fe:http-server ` tag after merge.

CMD -> ENTRYPOINT change is required to pass args in K8S Deployment.