### PR TITLE
systemd: provide an example how to set proper resource limits on `kuma-dp` and `kuma-cp` processes

### DIFF
--- a/vagrant/backend-v1/kuma/kuma-dp.service
+++ b/vagrant/backend-v1/kuma/kuma-dp.service
@@ -16,6 +16,25 @@ RestartSec=1s
 StartLimitIntervalSec=0
 StartLimitBurst=0
 User=vagrant
+# if you need your dataplane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-dp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-dp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-dp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/backend/kuma/kuma-dp.service
+++ b/vagrant/backend/kuma/kuma-dp.service
@@ -16,6 +16,25 @@ RestartSec=1s
 StartLimitIntervalSec=0
 StartLimitBurst=0
 User=vagrant
+# if you need your dataplane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-dp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-dp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-dp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/control-plane/kuma/kuma-cp.service
+++ b/vagrant/control-plane/kuma/kuma-cp.service
@@ -17,6 +17,25 @@ RestartSec=1s
 StartLimitIntervalSec=0
 StartLimitBurst=0
 User=vagrant
+# if you need your Control Plane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-cp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-dp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-cp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/elastic/kuma/kuma-dp.service
+++ b/vagrant/elastic/kuma/kuma-dp.service
@@ -16,6 +16,25 @@ RestartSec=1s
 StartLimitIntervalSec=0
 StartLimitBurst=0
 User=vagrant
+# if you need your dataplane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-dp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-dp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-dp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/frontend/kuma/kuma-dp.service
+++ b/vagrant/frontend/kuma/kuma-dp.service
@@ -16,6 +16,25 @@ RestartSec=1s
 StartLimitIntervalSec=0
 StartLimitBurst=0
 User=vagrant
+# if you need your dataplane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-dp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-dp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-dp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/kong/kuma/kuma-dp.service
+++ b/vagrant/kong/kuma/kuma-dp.service
@@ -16,6 +16,25 @@ RestartSec=1s
 StartLimitIntervalSec=0
 StartLimitBurst=0
 User=vagrant
+# if you need your dataplane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-dp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-dp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-dp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target

--- a/vagrant/redis/kuma/kuma-dp.service
+++ b/vagrant/redis/kuma/kuma-dp.service
@@ -16,6 +16,25 @@ RestartSec=1s
 StartLimitIntervalSec=0
 StartLimitBurst=0
 User=vagrant
+# if you need your dataplane to be able to handle a non-trivial number of concurrent connections
+# (a total of both incoming and outgoing connections), you need to set proper resource limits on
+# the `kuma-dp` process, especially maximum number of open files.
+#
+# it happens that `systemd` units are not affected by the traditional `ulimit` configuration,
+# and you must set resource limits as part of `systemd` unit itself.
+#
+# to check effective resource limits set on a running `kuma-dp` instance, execute
+#
+#   $ cat /proc/`pgrep kuma-dp`/limits
+#
+#   Limit                     Soft Limit           Hard Limit           Units
+#   ...
+#   Max open files            1024                 4096                 files
+#   ...
+#
+# for Kuma demo setup, we chose the same limit as `docker` and `containerd` set by default.
+# See https://github.com/containerd/containerd/issues/3201
+LimitNOFILE=1048576
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## PR Details

* provide an example how to set proper resource limits on `kuma-dp` and `kuma-cp` processes

### Issues resolved

Fix #53
