### PR TITLE
fix: update jaeger namespace in tracing mesh

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1034,7 +1034,7 @@ spec:
       sampling: 100.0
       type: zipkin
       conf:
-        url: http://jaeger-collector.default:9411/api/v2/spans
+        url: http://jaeger-collector.kuma-tracing:9411/api/v2/spans
 EOF
 ```
 


### PR DESCRIPTION
### Motivation and Context

The previous commit ea76cce8440f9c4c32355944d52eedab66632977 changed the method to install traffic tracing component on kubernetes. Going from using a local yaml file to using the default `kumactl install tracing` command. The problem is that the previous version was installed in the _default_ namespace when the new version is installed in the _kuma-tracing_.

### Full changelog

* fix: update jaeger namespace in tracing mesh

### Issues resolved

None
