### PR TITLE
docs: correct HealthCheck resource

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -829,7 +829,7 @@ To apply a health check policy to backend service, run the following:
 ```bash
 $ cat <<EOF | kubectl apply -f -
 apiVersion: kuma.io/v1alpha1
-kind: TraffiHealthCheckcRoute
+kind: HealthCheck
 metadata:
   name: frontend-to-backend
   namespace: kuma-demo
@@ -842,14 +842,10 @@ spec:
   - match:
       service: backend.kuma-demo.svc:3001
   conf:
-    activeChecks:
-      interval: 10s
-      timeout: 2s
-      unhealthyThreshold: 3
-      healthyThreshold: 1
-    passiveChecks:
-      unhealthyThreshold: 3
-      penaltyInterval: 5s
+    interval: 10s
+    timeout: 2s
+    unhealthyThreshold: 3
+    healthyThreshold: 1
 EOF
 ```
 


### PR DESCRIPTION
## PR Details

Updates to correct HealthCheck API. The validation webhook was rejecting the current `HealthCheck` even after the `kind` was corrected with the message:
```
The HealthCheck "frontend-to-backend" is invalid: 
* spec.conf.interval: must have a positive value
* spec.conf.timeout: must have a positive value
* spec.conf.unhealthyThreshold: must have a positive value
* spec.conf.healthyThreshold: must have a positive value
```

I think the [API docs here](https://kuma.io/docs/0.6.0/documentation/http-api/#health-check) also might be outdated. Happy to update those if there's a good source of truth -- thank you!

### Description

Corrects the `kind` and `spec`.

### Motivation and Context

Broken script

### Full changelog

* Sets `kind` from `TraffiHealthCheckcRoute` to `HealthCheck`
* Updates the conf

### Issues resolved

N/A