### PR TITLE
Update README.md - fix granular permissions, services use _ rather than .

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -661,10 +661,10 @@ metadata:
 spec:
   sources:
   - match:
-      service: kong-proxy.kuma-demo.svc:80
+      service: kong-proxy_kuma-demo_svc_80
   destinations:
   - match:
-      service: frontend.kuma-demo.svc:8080
+      service: frontend_kuma-demo_svc_8080
 ---
 apiVersion: kuma.io/v1alpha1
 kind: TrafficPermission
@@ -675,10 +675,10 @@ metadata:
 spec:
   sources:
   - match:
-      service: frontend.kuma-demo.svc:8080
+      service: frontend_kuma-demo_svc_8080
   destinations:
   - match:
-      service: backend.kuma-demo.svc:3001
+      service: backend_kuma-demo_svc_3001
 ---
 apiVersion: kuma.io/v1alpha1
 kind: TrafficPermission
@@ -689,10 +689,10 @@ metadata:
 spec:
   sources:
   - match:
-      service: backend.kuma-demo.svc:3001
+      service: backend_kuma-demo_svc_3001
   destinations:
   - match:
-      service: postgres.kuma-demo.svc:5432
+      service: postgres_kuma-demo_svc_5432
 EOF
 ```
 


### PR DESCRIPTION
## PR Details

Update README.md - fix granular permissions, services use _ rather than .
### Description

Change services from kong-proxy.kuma-demo.svc:80 to kong-proxy_kuma-demo_svc_80

### Motivation and Context

Demo doesn't work with Kuma 0.6

### Full changelog

Just changes readme


### Issues resolved

Fixes upstream connect error or disconnect/reset before headers. reset reason: connection termination
