### PR TITLE
Migration 0.6.0

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-KUMA_VERSION = "0.6.0"
+KUMA_VERSION = "0.5.0"
 KUMA_HOME    = "/opt/kuma"
 
 KUMA_CONTROL_PLANE_IP      = "192.168.33.10"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-KUMA_VERSION = "0.5.0"
+KUMA_VERSION = "0.6.0"
 KUMA_HOME    = "/opt/kuma"
 
 KUMA_CONTROL_PLANE_IP      = "192.168.33.10"

--- a/vagrant/backend-v1/kuma/dataplane.yaml
+++ b/vagrant/backend-v1/kuma/dataplane.yaml
@@ -2,14 +2,17 @@ type: Dataplane
 mesh: default
 name: backend-v1
 networking:
+  address: {{ DATAPLANE_IP }} 
   inbound:
-  - interface: {{ DATAPLANE_IP }}:13001:3001
+  - interface: 13001
+    port: 13001
+    servicePort: 3001
     tags:
       service: backend
       version: v1
       protocol: http
   outbound:
-  - interface: :26379
+  - port: 26379
     service: redis
-  - interface: :25432
+  - port: 25432
     service: postgresql

--- a/vagrant/backend-v1/kuma/dataplane.yaml
+++ b/vagrant/backend-v1/kuma/dataplane.yaml
@@ -4,8 +4,7 @@ name: backend-v1
 networking:
   address: {{ DATAPLANE_IP }} 
   inbound:
-  - interface: 13001
-    port: 13001
+  - port: 13001
     servicePort: 3001
     tags:
       service: backend

--- a/vagrant/backend/kuma/dataplane.yaml
+++ b/vagrant/backend/kuma/dataplane.yaml
@@ -2,14 +2,16 @@ type: Dataplane
 mesh: default
 name: backend
 networking:
+  address: {{ DATAPLANE_IP }} 
   inbound:
-  - interface: {{ DATAPLANE_IP }}:13001:3001
+  - port: 13001
+    servicePort: 3001
     tags:
       service: backend
       version: v0
       protocol: http
   outbound:
-  - interface: :26379
+  - port: 26379
     service: redis
-  - interface: :25432
+  - port: 25432
     service: postgresql

--- a/vagrant/frontend/kuma/dataplane.yaml
+++ b/vagrant/frontend/kuma/dataplane.yaml
@@ -2,11 +2,13 @@ type: Dataplane
 mesh: default
 name: frontend
 networking:
+  address: {{ DATAPLANE_IP }}
   inbound:
-  - interface: {{ DATAPLANE_IP }}:18080:8080
+  - port: 18080
+    servicePort: 8080
     tags:
       service: frontend
       protocol: http
   outbound:
-  - interface: :23001
+  - port: 23001
     service: backend

--- a/vagrant/kong/kuma/dataplane.yaml
+++ b/vagrant/kong/kuma/dataplane.yaml
@@ -7,5 +7,5 @@ networking:
     tags:
       service: kong
   outbound:
-  - interface: :28080
+  - port: 28080
     service: frontend 

--- a/vagrant/postgresql/kuma/dataplane.yaml
+++ b/vagrant/postgresql/kuma/dataplane.yaml
@@ -2,7 +2,9 @@ type: Dataplane
 mesh: default
 name: postgresql
 networking:
+  address: {{ DATAPLANE_IP }}
   inbound:
-  - interface: {{ DATAPLANE_IP }}:15432:5432
+  - port: 15432
+    servicePort: 5432
     tags:
       service: postgresql

--- a/vagrant/redis/kuma/dataplane.yaml
+++ b/vagrant/redis/kuma/dataplane.yaml
@@ -2,7 +2,9 @@ type: Dataplane
 mesh: default
 name: redis
 networking:
+  address: {{ DATAPLANE_IP }}
   inbound:
-  - interface: {{ DATAPLANE_IP }}:16379:6379
+  - port: 16379
+    servicePort: 6379
     tags:
       service: redis


### PR DESCRIPTION
## PR Details

Update dataplane.yaml for Kuma 0.6.0

### Description

Fixed each dataplane.yaml in vagrant. ( universal mode only )

### Motivation and Context

The demo doesn't work with Kuma 0.6.0

### Full changelog

Changes dataplane.yaml to according to the latest spec.

### Issues resolved

The demo can work with Kuma 0.6.0 as well as 0.5.0.

